### PR TITLE
Select all input text on openFindWindow

### DIFF
--- a/src/findInPage.js
+++ b/src/findInPage.js
@@ -99,6 +99,7 @@ class FindInPage extends Find{
   openFindWindow () {
     if (this[hasOpened]) {
       focusInput.call(this)
+      this[findInput].select()
       return false
     }
     if (!this.initialize()) return false


### PR DESCRIPTION
Select existing input text if openFindWindow is called and FindInPage has already been opened. This makes the behavior more similar to how find works in Chrome.